### PR TITLE
исправлено в соответствии с http://xmlcalendar.ru/

### DIFF
--- a/Mindbox.WorkingCalendar/RussianWorkingDaysExceptionsProvider.cs
+++ b/Mindbox.WorkingCalendar/RussianWorkingDaysExceptionsProvider.cs
@@ -93,6 +93,9 @@ namespace Mindbox.WorkingCalendar
 					case "2":
 						dayType = DayType.Short;
 						break;
+					case "3":
+						dayType = DayType.Working;
+						break;
 					default:
 						throw new NotSupportedException();
 				}


### PR DESCRIPTION
тип дня: 1 - выходной день, 2 - рабочий и сокращенный (может быть использован для любого дня недели), 3 - рабочий день (суббота/воскресенье)